### PR TITLE
build:Update TypeORM Migration Command and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ HTTP server for Pinatani
   - Run TypeORM CLI commands.
 - **migration:generate**: `npm run typeorm -- migration:generate -n`
   - Generate a new migration with TypeORM.
+  - example use: `npm run migration:generate --filename=migrationName`
 - **migration:run**: `npm run typeorm -- migration:run -d ./ormconfig.ts`
   - Run pending migrations with TypeORM.
 - **migration:revert**: `npm run typeorm -- migration:revert -d ./ormconfig.ts`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docker:restart": "docker-compose restart",
     "docker:logs": "docker-compose logs -f",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
-    "migration:generate": "npm run typeorm -- migration:generate -n",
+    "migration:generate": "npm run typeorm -- migration:generate src/migrations/$npm_config_filename -d ./ormconfig.ts",
     "migration:run": "npm run typeorm -- migration:run -d ./ormconfig.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d ./ormconfig.ts"
   },


### PR DESCRIPTION
### This PR introduces the following changes:

1. **Update to `package.json`:**
   - Modified the `migration:generate` script in `package.json` to include a more specific file path for generated migrations. The command now generates migrations in the `src/migrations/` directory using a dynamic filename (`$npm_config_filename`).
   - The new command:
     ```json
     "migration:generate": "npm run typeorm -- migration:generate src/migrations/$npm_config_filename -d ./ormconfig.ts"
     ```

2. **Documentation Update (`README.md`):**
   - Added an example usage for the `migration:generate` command in the `README.md` to clarify how to use the updated migration script.
   - Example added:
     ```markdown
     example use: `npm run migration:generate --filename=migrationName`
     ```

### **Rationale:**
- The changes are made to ease the process of generating migrations by standardizing the command and its usage. This ensures developers can generate migrations more efficiently and with less room for error.
- Updating the documentation provides clear guidance on how to use the new script, reducing the chances of errors.

### **Testing:**
- Ensure that running the migration generation command creates the migration file in the correct directory with the expected filename.
- Verify that the documentation examples are accurate and lead to the correct outcomes when followed.
